### PR TITLE
RN 0.54 compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-import {Component} from 'react'
+import React, {Component} from 'react'
 import {Text} from 'react-native'
 
 
@@ -8,7 +8,7 @@ import code128 from "./code128"
 export default class KsiBarcode extends Component{
     render() {
         const {text, style, ...others } = this.props
-        return <Text {...others} style= { [{ color: 'black', fontSize:50, fontFamily: 'code128' }, style, ]} >{ code128(text) }</Text >
+        return <Text {...others} style= { [{ color: 'black', fontSize:50, fontFamily: 'code128' }, style, ]} >{ code128(text) }</Text>
 
     }
 }

--- a/index.js
+++ b/index.js
@@ -1,17 +1,14 @@
 'use strict';
-var React = require('react');
-var ReactNative = require('react-native');
+import {Component} from 'react'
+import {Text} from 'react-native'
 
-var {
-    Text,
-} = ReactNative;
 
 import code128 from "./code128"
 
-export default React.createClass({
+export default class KsiBarcode extends Component{
     render() {
         const {text, style, ...others } = this.props
         return <Text {...others} style= { [{ color: 'black', fontSize:50, fontFamily: 'code128' }, style, ]} >{ code128(text) }</Text >
 
     }
-})
+}

--- a/package.json
+++ b/package.json
@@ -37,5 +37,9 @@
     "type": "git",
     "url": "git://github.com/helpkang/react-native-ksi-barcode.git"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "react": "^16.3.0-alpha.1",
+    "react-native": "0.54.1"
+  }
 }


### PR DESCRIPTION
What about merge this and make it work on RN 0.54. React.createClass is not used anymore